### PR TITLE
Remove CNAME file.

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-numpy.org


### PR DESCRIPTION
Looks like we can only have a single CNAME file per organization. In order to switch the deployment to the `gh-pages` branch over on numpy.org, we should remove this CNAME file. According to this forum post, changes should propagate in approx. 10 minutes: https://github.community/t/how-to-move-my-domain-to-another-repository/11000